### PR TITLE
[김동규] #13 가계부 카테고리 생성/조회/수정/삭제/복구 기능 구현

### DIFF
--- a/account_books/serializers.py
+++ b/account_books/serializers.py
@@ -96,3 +96,34 @@ class AccountBookCategorySerializer(ModelSerializer):
             'id'    : {'read_only': True},
             'status': {'read_only': True},
         }
+        
+        
+class AccountBookCategoryDetailSerializer(ModelSerializer):
+    """
+    Assignee: 김동규
+    
+    detail: 가계부 카테고리 데이터 시리얼라이저[PATCH 기능 유효성 검사]
+    model: AccountBookCategory
+    """
+    
+    nickname = serializers.SerializerMethodField()
+    
+    def get_nickname(self, obj: AccountBookCategory) -> str:
+        return obj.user.nickname
+    
+    def update(self, instance: AccountBookCategory, validated_data: OrderedDict) -> object:
+        
+        instance.name = validated_data.get('name', instance.name)
+        instance.save()
+        
+        return instance 
+    
+    class Meta:
+        model  = AccountBookCategory
+        fields = [
+            'id', 'nickname', 'name', 'status'
+        ]
+        extra_kwargs = {
+            'id'    : {'read_only': True},
+            'status': {'read_only': True},
+        }

--- a/account_books/serializers.py
+++ b/account_books/serializers.py
@@ -2,7 +2,7 @@ from typing                     import OrderedDict
 from rest_framework             import serializers
 from rest_framework.serializers import ModelSerializer
 
-from account_books.models import AccountBook
+from account_books.models import AccountBook, AccountBookCategory
 
 
 class AccountBookSerializer(ModelSerializer):
@@ -62,6 +62,35 @@ class AccountBookDetailSerializer(ModelSerializer):
         model  = AccountBook
         fields = [
             'id', 'nickname', 'name', 'budget', 'status' 
+        ]
+        extra_kwargs = {
+            'id'    : {'read_only': True},
+            'status': {'read_only': True},
+        }
+        
+
+class AccountBookCategorySerializer(ModelSerializer):
+    """
+    Assignee: 김동규
+    
+    detail: 가계부 카테고리 데이터 시리얼라이저[GET/POST 기능 유효성 검사]
+    model: AccountBookCategory
+    """
+    
+    nickname = serializers.SerializerMethodField()
+    
+    def get_nickname(self, obj: AccountBookCategory) -> str:
+        return obj.user.nickname
+    
+    def create(self, validated_data: OrderedDict) -> object:
+        category = AccountBookCategory.objects\
+                                      .create(**validated_data)
+        return category
+    
+    class Meta:
+        model  = AccountBookCategory
+        fields = [
+            'id', 'nickname', 'name', 'status'
         ]
         extra_kwargs = {
             'id'    : {'read_only': True},

--- a/account_books/urls.py
+++ b/account_books/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
 from account_books.views.account_books           import AccountBookView, AccountBookDetailView, AccountBookRestoreView
-from account_books.views.account_book_categories import AccountBookCategoryView
+from account_books.views.account_book_categories import AccountBookCategoryView, AccountBookCategoryDetailView,\
+                                                        AccountBookCategoryRestoreView
 
 """
 가계부 url patterns
@@ -17,4 +18,6 @@ urlpatterns = [
 """
 urlpatterns += [
     path('/categories', AccountBookCategoryView.as_view()),
+    path('/categories/<int:account_book_category_id>', AccountBookCategoryDetailView.as_view()),
+    path('/categories/<int:account_book_category_id>/restore', AccountBookCategoryRestoreView.as_view()),
 ]

--- a/account_books/urls.py
+++ b/account_books/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
-from account_books.views.account_books import AccountBookView, AccountBookDetailView, AccountBookRestoreView
-
+from account_books.views.account_books           import AccountBookView, AccountBookDetailView, AccountBookRestoreView
+from account_books.views.account_book_categories import AccountBookCategoryView
 
 """
 가계부 url patterns
@@ -10,4 +10,11 @@ urlpatterns = [
     path('', AccountBookView.as_view()),
     path('/<int:account_book_id>', AccountBookDetailView.as_view()),
     path('/<int:account_book_id>/restore', AccountBookRestoreView.as_view()),
+]
+
+"""
+가계부 카테고리 url patterns
+"""
+urlpatterns += [
+    path('/categories', AccountBookCategoryView.as_view()),
 ]

--- a/account_books/views/account_book_categories.py
+++ b/account_books/views/account_book_categories.py
@@ -1,0 +1,97 @@
+from django.db.models           import Q
+
+from drf_yasg                   import openapi
+from drf_yasg.utils             import swagger_auto_schema
+
+from rest_framework.views       import APIView
+from rest_framework.response    import Response
+from rest_framework.permissions import IsAuthenticated
+
+from account_books.models       import AccountBookCategory
+from account_books.serializers  import AccountBookCategorySerializer
+
+from core.utils.decorator       import query_debugger
+
+
+class AccountBookCategoryView(APIView):
+    """
+    Assignee: 김동규
+    
+    query string: search, sort, status, offset, limit
+    request body: name
+    return: json
+    detail:
+      - GET: 인증/인가에 통과한 유저는 본인의 카테고리 리스트 정보를 조회할 수 있습니다.
+        > 부가기능
+          * 카테고리 검색기능(카테고리 이름을 기준으로 검색 키워드 적용)
+          * 정렬 기능(생성일자를 기준으로 정렬)
+          * 카테고리 필터링 기능(사용중인/삭제된 카테고리를 기준으로 필터링)
+          * 페이지네이션 기능(원하는 크기의 데이터 개수를 호출)
+      - POST: 인증/인가에 통과한 유저는 카테고리를 생성할 수 있습니다.
+        > 필수 입력값: name
+    """
+    
+    permission_classes = [IsAuthenticated]
+    
+    search = openapi.Parameter('search', openapi.IN_QUERY, required=False, pattern='?search=', type=openapi.TYPE_STRING)
+    sort   = openapi.Parameter('sort', openapi.IN_QUERY, required=False, pattern='?sort=', type=openapi.TYPE_STRING)
+    status = openapi.Parameter('status', openapi.IN_QUERY, required=False, pattern='?status=', type=openapi.TYPE_STRING)
+    offset = openapi.Parameter('offset', openapi.IN_QUERY, required=False, pattern='?offset=', type=openapi.TYPE_STRING)
+    limit  = openapi.Parameter('limit', openapi.IN_QUERY, required=False, pattern='?limit=', type=openapi.TYPE_STRING)
+    
+    @query_debugger
+    @swagger_auto_schema(responses={200: AccountBookCategorySerializer}, manual_parameters=[search, sort, status, offset, limit])
+    def get(self, request):
+        """
+        GET: 가계부 카테고리 조회(리스트) 기능
+        """
+        user = request.user
+            
+        search = request.GET.get('search', None)
+        sort   = request.GET.get('sort', 'up_to_date')
+        status = request.GET.get('status', 'deleted')
+        offset = int(request.GET.get('offset', 0))
+        limit  = int(request.GET.get('limit', 10))
+        
+        """
+        정렬 기준
+        """ 
+        sort_set = {
+            'up_to_date' : '-created_at',
+            'out_of_date': 'created_at'
+        }
+        
+        """
+        Q 객체 활용:
+          - 검색 기능(카테고리 이름을 기준으로 검색 필터링)
+          - 필터링 기능(본인의 카테고리 필터링)
+        """
+        q = Q()
+        
+        if search:
+            q |= Q(name__icontains=search)
+            
+        if user:
+            q &= Q(user=user)
+            
+        categories = AccountBookCategory.objects\
+                                        .select_related('user')\
+                                        .filter(q)\
+                                        .exclude(status__iexact=status)\
+                                        .order_by(sort_set[sort])[offset:offset+limit]
+        
+        serializer = AccountBookCategorySerializer(categories, many=True)
+        return Response(serializer.data, status=200)
+    
+    @swagger_auto_schema(request_body=AccountBookCategorySerializer, responses={201: AccountBookCategorySerializer})
+    def post(self, request):
+        """
+        POST: 가계부 카테고리 생성 기능
+        """
+        user = request.user
+        
+        serializer = AccountBookCategorySerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save(user=user)
+            return Response(serializer.data, status=201)
+        return Response(serializer.errors, status=400)

--- a/core/utils/get_obj_n_check_err.py
+++ b/core/utils/get_obj_n_check_err.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Any
 
-from account_books.models import AccountBook
+from account_books.models import AccountBook, AccountBookCategory
 from users.models         import User
 
 
@@ -32,3 +32,33 @@ class GetAccountBook:
             return None, f'다른 유저의 가계부입니다.'
         
         return book, None
+    
+    
+class GetAccountBookCategory:
+    """
+    Assignee: 김동규
+    
+    param: account_book_category_id, user
+    return: obj, err
+    detail:
+      - 가계부 카테고리 id를 통해 카테고리 객체(정보)의 존재여부 확인
+      - 가계부 카테고리 객체의 유저정보와 API를 요청한 유저정보가 일치하는지 확인
+    """
+    
+    def get_category_n_check_error(account_book_category_id: int, user: User) -> Tuple[Any, str]:
+        """
+        카테고리 존재여부 확인
+        """
+        try:
+            category = AccountBookCategory.objects\
+                                          .get(id=account_book_category_id)
+        except AccountBookCategory.DoesNotExist:
+            return None, f'가계부 카테고리 {account_book_category_id}(id)는 존재하지 않습니다.'
+        
+        """
+        본인의 카테고리인지 확인
+        """
+        if not user.nickname == category.user.nickname:
+            return None, f'다른 유저의 가계부 카테고리입니다.'
+        
+        return category, None


### PR DESCRIPTION
<!--PR 제목 : [ 이름 ] #이슈번호 - 구현 내용 -->

# 구현 목표
<!-- 이슈 번호 맵핑해주세요. 간단한 요약을 해주세요.-->
- #13  
- 가계부 카테고리 생성/리스트 조회/수정/삭제/복구 기능 구현

# 변경 사항
<!--관련 없는 내용을 지워주세요-->

- [x] 기능 추가
- [ ] 셋업 
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드리뷰 반영
- [ ] 컨벤션 수정
- [ ] 레거시코드 제거 및 Breaking

<!--⬇ 변경사항을 자세히 작성합니다. ⬇-->
- 가계부 카테고리 생성 기능 구현
   - 인증/인가에 통과한 유저만 가계부 카테고리 생성 가능
   - 필수 입력값(카테고리 이름) 확인
- 가계부 카테고리 리스트 조회 기능 구현
   - 인증/인가에 통과한 유저만 본인의 가계부 카테고리 리스트 조회 가능
   - 부가기능:
      - 카테고리 검색기능
      - 카테고리 정렬기능
      - 카테고리 필터링기능(사용중인/삭제된 가계부)
      - 페이지네이션 기능
- 가계부 카테고리 수정 기능
   - 인증/인가에 통과한 유저만 본인의 가계부 카테고리 수정 가능
   - 카테고리의 이름만 수정 가능
   - 수정 요청한 카테고리가 존재하는지 확인
   - 수정 요청한 카테고리가 본인의 가계부인지 확인
- 가계부 카테고리 삭제 기능
   - 인증/인가에 통과한 유저만 본인의 가계부 카테고리 삭제 가능
   - 삭제 요청한 카테고리가 존재하는지 확인
   - 삭제 요청한 카테고리가 본인의 가계부인지 확인
   - 이미 삭제된 카테고리인지 확인
- 가계부 카테고리 복구 기능
   - 인증/인가에 통과한 유저만 본인의 가계부 카테고리 복구 가능
   - 복구 요청한 카테고리가 존재하는지 확인
   - 복구 요청한 카테고리가 본인의 가계부인지 확인
   - 이미 복구된 카테고리인지 확인

# 테스트 여부
<!--테스트 통과 여부를 체크해주세요-->
- [x] TEST 

# 스크린샷 
<!--필요한 경우 첨부합니다-->

